### PR TITLE
wp-outdated.yml の条件式を修正

### DIFF
--- a/.github/workflows/wp-outdated.yml
+++ b/.github/workflows/wp-outdated.yml
@@ -23,7 +23,7 @@ jobs:
         id: wp_version
 
       - name: Update Issue if needed
-        if: steps.wp_version.outputs.should_update
+        if: ${{ 'true' == steps.wp_version.outputs.should_update }}
         uses: actions-ecosystem/action-create-issue@v1
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
'true' か 'false' の文字列で返ってくるので、常にtrueに判定されていた。