### PR TITLE
Add wp-plugin-audit workflow

### DIFF
--- a/.github/workflows/wp-plugin-audit.yml
+++ b/.github/workflows/wp-plugin-audit.yml
@@ -1,0 +1,14 @@
+name: WP Plugin Audit
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    uses: tarosky/workflows/.github/workflows/wp-plugin-audit.yml@main
+    with:
+      slug: rich-taxonomy
+      language: ja
+    secrets: inherit


### PR DESCRIPTION
## Summary
- tarosky/workflows の `wp-plugin-audit` 共有ワークフローを追加
- 毎月1日に WordPress.org API とサポートフォーラムからプラグインの健全性を自動分析
- 手動実行（workflow_dispatch）にも対応

## Test plan
- [ ] Actions タブで手動実行し、正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)