### PR TITLE
Fix plugin-audit workflow path

### DIFF
--- a/.github/workflows/wp-plugin-audit.yml
+++ b/.github/workflows/wp-plugin-audit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   audit:
-    uses: tarosky/workflows/.github/workflows/wp-plugin-audit.yml@main
+    uses: tarosky/workflows/.github/workflows/plugin-audit.yml@main
     with:
       slug: rich-taxonomy
       language: ja


### PR DESCRIPTION
## Summary
- #73 で追加した wp-plugin-audit.yml の共有ワークフローパスを修正
- `wp-plugin-audit.yml` → `plugin-audit.yml`

## Test plan
- [ ] Actions タブで手動実行し、正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)