### PR TITLE
CLAUDE.md のバージョン参照化 + Requires at least を 6.6 に更新（#120 対応）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,16 +54,21 @@ npm run lint          # ESLint + Stylelint
 
 PR作成時に以下が自動実行される。すべてパスしないとマージ不可：
 
-- PHPUnit（PHP 7.4/8.0 × WP latest/5.9）
+- PHPUnit（PHP × WP のバージョンマトリックスは `.github/workflows/test.yml` を参照）
 - PHPCS（WordPress-Core）
 - PHPStan Level 5
 - アセットビルド確認
+
+> **バージョンの情報源（Single Source of Truth）** — 本ドキュメントには具体的なバージョン番号を記載しない（乖離防止のため）。
+> - **対応 PHP**: `composer.json`（`require.php` / `config.platform.php`）が正。`rich-taxonomy.php` の `Requires PHP` はこれに追従する
+> - **Node**: `.node-version`
+> - **CI テストマトリックス（PHP × WP）**: `.github/workflows/test.yml`
 
 ## コーディング規約
 
 - WordPress Coding Standards 準拠
 - PSR-0 オートロード（`Tarosky\RichTaxonomy` → `src/`）
-- PHP 7.0+ 互換（ただし CI は 7.4+ でテスト）
+- 対応 PHP バージョンは `composer.json`（`require.php` / `config.platform.php`）と CI マトリックス（`.github/workflows/test.yml`）に従う
 - 新規コードは PHPStan Level 5 をパスすること（既存のbaselineエラーを増やさない）
 
 ## 注意事項

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Tags: taxonomy, terms, seo  
 Contributors: tarosky, Takahashi_Fumiki, megane9988, tswallie  
+Requires at least: 6.6  
 Tested up to: 6.9  
 Requires PHP: 8.1  
 Stable Tag: nightly  

--- a/rich-taxonomy.php
+++ b/rich-taxonomy.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://wordpress.org/plugins/rich-taxonomy/
  * Author: Tarosky INC.
  * Version: nightly
- * Requires at least: 5.9
+ * Requires at least: 6.6
  * Requires PHP: 8.1
  * Author URI: https://tarosky.co.jp/
  * License: GPL3 or later


### PR DESCRIPTION
## 概要

`#120` の推奨アクションを一括対応。CLAUDE.md のバージョン番号ハードコードを排除し、あわせて `Requires at least` を実態（CI がテストする WP 6.6）に揃えました。

## 背景

Issue #120 の指摘どおり、`.claude/CLAUDE.md` の記述（`PHP 7.4/8.0 × WP latest/5.9`、`PHP 7.0+ 互換`）が実態と乖離していました。実態は #111（`Closes #75`）で PHP 8.1 に引き上げ済み（composer `>=8.1`、test.yml `8.1/8.3`、ヘッダー `Requires PHP: 8.1`）。

根本原因は「ドキュメント／メタデータにバージョン番号を重複して持っていること」なので、CLAUDE.md は情報源を参照する方式に切り替え、`Requires at least` は実態に合わせました。

## Single Source of Truth の方針

- **対応 PHP**: `composer.json`（`require.php` / `config.platform.php`）が正。`rich-taxonomy.php` の `Requires PHP` はこれに追従
- **Node**: `.node-version`
- **CI テストマトリックス（PHP × WP）**: `.github/workflows/test.yml`

## 変更内容

### ① CLAUDE.md の CI マトリックス記述（#120 推奨1）
`PHPUnit（PHP 7.4/8.0 × WP latest/5.9）` → マトリックスは test.yml 参照 + 情報源を明示

### ② CLAUDE.md のコーディング規約（#120 推奨2）
`PHP 7.0+ 互換（ただし CI は 7.4+ でテスト）` → composer.json / test.yml 参照

### ③ Requires at least を 6.6 に更新（#120 推奨3）
- `rich-taxonomy.php`: `Requires at least: 5.9` → `6.6`（CI がテストする WP 最低バージョンに整合）
- `README.md`: `Requires at least: 6.6` を新規追加（従来この行が欠落しており、readme.txt 生成時に WordPress.org へ最低 WP バージョンが表示されない状態だった）

> **補足**: 6.6 は「6.6 未満で動かない」ではなく「6.6 未満は CI 未検証のため保証しない」という宣言。将来より低い WP を保証したい場合は test.yml のマトリックスに下限を追加して検証する運用とする。

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)