### PR TITLE
README に Use Cases セクションを追加（トピッククラスター等）

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ A WordPress plugin that enhances taxonomy archives by replacing them with custom
 - Includes a **Taxonomy Archive Block** to display posts.
 - Fully customizable via templates and filter hooks.
 
+### Use Cases
+
+**Topic clusters & pillar pages (SEO).** Turn a category or tag archive into a *pillar page* that introduces the topic and links out to its individual posts (the *cluster content*). This is the topic-cluster model used in modern SEO: one authoritative hub page that consolidates internal links and signals topical authority — instead of a bare, auto-generated list of post titles.
+
+**Category & taxonomy landing pages.** Give any taxonomy term a fully designed landing page — hero, introduction, curated blocks — while still automatically listing the posts assigned to that term. Ideal for product categories, service areas, or editorial sections.
+
+**Content hubs.** Build a curated hub for a series, event, or campaign: write an editorial introduction in the block editor, then let the Taxonomy Archive Block surface the latest related posts automatically.
+
 ### How It Works
 
 The Taxonomy Page will override the **first page** of a term archive. In **Settings** you can choose which taxonomies should have the option to create a Taxonomy Page.


### PR DESCRIPTION
## 概要

`#76`（アクティブインストール数・認知度が低い）対応の一環。README の Description に **Use Cases** セクションを追加し、プラグインの用途と検索性を向上させる。

Rich Taxonomy はタームアーカイブをリッチなランディングページに置き換えるプラグインで、本質的に**トピッククラスター／ピラーページ**構築ツールです。従来の Description は機能の羅列（何ができるか）に偏り、「誰が・なぜ使うか」が不足していました。

## 追加したユースケース

- **Topic clusters & pillar pages (SEO)** — タームアーカイブをピラーページ化し、内部リンクを集約してトピックの権威性を高める（本プラグインの主用途）
- **Category & taxonomy landing pages** — 商品カテゴリー・サービス地域・編集セクション向けのランディングページ
- **Content hubs** — シリーズ／イベント／キャンペーンのキュレーションハブ

## #76 の推奨アクションとの対応

- ✅「プラグイン説明文にユースケース・導入メリットを具体的に記載し、検索性を向上させる」
- （別途）スクリーンショット・バナー画像、短い説明文の刷新は今後対応

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)