### PR TITLE
タグ最適化・wp_register_style タイポ修正・Changelog 補完（#76）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rich Taxonomy
 
-Tags: taxonomy, terms, seo  
+Tags: seo, category, topic cluster, pillar page, landing page  
 Contributors: tarosky, Takahashi_Fumiki, megane9988, tswallie  
 Tested up to: 6.9  
 Requires PHP: 8.1  
@@ -88,7 +88,7 @@ To change the look & feel, `rich_taxonomy_block_asset_style` is the best startin
 ```php
 // Register style.
 add_action( 'init', function() {
-    wp_registeR_style( 'my-archive-block', $url, $deps, $version );
+    wp_register_style( 'my-archive-block', $url, $deps, $version );
 } );
 
 // Override handle.
@@ -150,6 +150,23 @@ Please create a new ticket on the support forum.
 Create a new [issue](https://github.com/tarosky/rich-taxonomy/issues) or send [pull requests](https://github.com/tarosky/rich-taxonomy/pulls).
 
 ## Changelog
+
+### 1.2.1
+
+* Update Node.js version to 20 in release workflow.
+
+### 1.2.0
+
+* Add block theme (FSE) support for template override.
+* Fix template override when `single.php` exists in classic themes.
+* Fix layout of the sync information notice.
+* Replace Gulp build system with npm scripts and `@kunoichi/grab-deps`.
+
+### 1.1.8
+
+* Add pagination to the broken page warning.
+* Add notices to improve UX.
+* Bugfix: handle missing taxonomy and null term.
 
 ### 1.1.7
 


### PR DESCRIPTION
## 概要

`#76`（認知度・検索性）対応の一環。README の3点を修正。

## 変更内容

### 1. Tags 最適化（検索性・マーケティング視点）
`taxonomy, terms, seo` → **`seo, category, topic cluster, pillar page, landing page`**

`taxonomy` / `terms` は readme 本文（タイトル・Description）で自然にインデックスされるため、限られたタグ枠は「本文に埋もれがちだが検索意図の強い語」に割り当てる方針に変更：

- `category` — ユーザーは "taxonomy" より "category" で検索する（検索ボリューム大）
- `topic cluster` / `pillar page` — SEO クラスター訴求の鉄板ペア
- `landing page` — ランディングページ用途

### 2. `wp_register_style` タイポ修正（バグ）
「Example: Override Style」のコード例が `wp_registeR_style`（`R` が大文字）になっており、コピペしたユーザーが `Call to undefined function` で落ちる状態だった。

### 3. Changelog 補完
`1.1.7` を最後に `1.1.8` / `1.2.0` / `1.2.1` が欠落していた。git 履歴・リリースノートから復元：

- **1.2.0**: ブロックテーマ（FSE）対応、classic テーマの `single.php` 存在時の挙動修正、grab-deps 移行など
- **1.1.8**: 破損ページ警告のページネーション、UX 向上通知、term null バグ修正
- **1.2.1**: リリースワークフローの Node.js 更新

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)