### PR TITLE
1.3.0 の changelog を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ Create a new [issue](https://github.com/tarosky/rich-taxonomy/issues) or send [p
 
 ## Changelog
 
+### 1.3.0
+
+* Add support for creating a Taxonomy Page for a taxonomy's base URL (the whole archive), in addition to individual terms.
+* Raise minimum requirements to PHP 8.1 and WordPress 6.6.
+* Confirm compatibility with WordPress 7.0.
+* Update the plugin icon.
+
 ### 1.2.1
 
 * Update Node.js version to 20 in release workflow.


### PR DESCRIPTION
## 概要

次リリースを **1.3.0**（マイナー）として、1.2.1 以降のユーザー向け変更を README の Changelog に追記。

## なぜ 1.2.2 ではなく 1.3.0 か

1.2.1 以降にユーザー影響のある変更が2点あり、パッチでは過小表現のため：
- **新機能**：タクソノミーのベースURL（アーカイブ全体）用の固定ページ作成に対応（#61 / #62）
- **最低要件 PHP 8.1 化**（#111）— 8.1 未満のユーザーは以後の更新を受け取れなくなる互換性変更

## 追記内容（ユーザー向けに蒸留）

```
### 1.3.0
* Add support for creating a Taxonomy Page for a taxonomy's base URL (the whole archive), in addition to individual terms.
* Raise minimum requirements to PHP 8.1 and WordPress 6.6.
* Confirm compatibility with WordPress 7.0.
* Update the plugin icon.
```

内部変更（CI・CLAUDE.md・dependabot・claude-review 等 30本超のPR）は changelog から意図的に除外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)